### PR TITLE
[WIP] Analyze vcpkg failing on GitHub runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       - run: |
           . <(curl https://aka.ms/vcpkg-init.sh -L)
           vcpkg activate
-          cbuild get_started.csolution.yml --packs --update-rte --configuration .debug+avh
+          cbuild get_started.csolution.yml --packs --update-rte --context .debug+avh
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -12,7 +12,6 @@
     }
   ],
   "requires": {
-    "microsoft:cmake": "^3.25.2",
     "microsoft:ninja": "^1.10.2",
     "arm:compilers/arm/arm-none-eabi-gcc": "^12.2.1-0",
     "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.0.0-0"


### PR DESCRIPTION
Removing `cmake` from vcpkg-configuration.json solves the problem.
It looks like the vcpkg tar-extractor has some issues. 

This is reported as microsoft/vcpkg#32234.