### PR TITLE
Revert "[WIP] Analyze vcpkg failing on GitHub runners (#9)"

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -12,6 +12,7 @@
     }
   ],
   "requires": {
+    "microsoft:cmake": "^3.25.2",
     "microsoft:ninja": "^1.10.2",
     "arm:compilers/arm/arm-none-eabi-gcc": "^12.2.1-0",
     "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.0.0-0"


### PR DESCRIPTION
This reverts commit 0d8a261aa160bfc2fcd7040376607c7627701690.